### PR TITLE
Initial version of the AUTHORIZED_CONTRIBUTORS.md.

### DIFF
--- a/AUTHORIZED_CONTRIBUTORS.md
+++ b/AUTHORIZED_CONTRIBUTORS.md
@@ -1,0 +1,26 @@
+# TiDev Authorized Contributors
+In order to contribute code, docs, modules, etc to the TiDev project, you are required to sign-and-complete a copy of the TiDev CLA.
+
+You can review the latest version of the CLA on our organization-docs Github repository here:
+https://github.com/tidev/organization-docs/blob/main/CONTRIBUTOR_CLA.pdf
+
+Here's our process for accepting a signed CLA:
+
+ 1. Contact Josh Lambert either via TiSlack or via email (josh.lambert@centrevilletech.com) and request an e-sign link containing the CLA. Make sure you include the email address in your message that you want to receive the e-sign request!
+ 2. Complete the e-sign link when it arrives in your email from the TiDev Docusign account.
+ 3. Your name will appear on the list below within 5 business days, at which point, you'll be eligible to submit code and other IP to the TiDev project.
+ 
+
+> **PLEASE NOTE:** We only accept signed CLAs via Docusign to ensure we're all using the correct version of this document.
+
+Below is the list of users that have successfully completed the CLA document for TiDev and are authorized to submit work to the TiDev projects:
+
+|Signer|Github Username|CLA Version|Date Signed|
+|--|--|--|--|
+|Ray Belisle|raybelisle|1.0|March 3rd, 2022|
+|Jason Kneen|jasonkneen|1.0|March 3rd, 2022|
+|Richard Lustemburg|rlustemberg|1.0|March 3rd, 2022|
+|Hans Knöchel|hansemannn|1.0|March 3rd, 2022|
+|Chris Barber|cb1kenobi|1.0|March 2nd, 2022|
+|Sebastian Klaus|caspahouzer|1.0|March 2nd, 2022|
+|Josh Lambert|joshualambert|1.0|March 2nd, 2022|


### PR DESCRIPTION
This PR adds the list of authorized contributors to the TiDev projects. Authorized contributors = people that have completed the TiDev CLA via the TiDev Docusign account.